### PR TITLE
Fix contrast of invalid scope

### DIFF
--- a/themes/Tinacious Design (Light)-color-theme.json
+++ b/themes/Tinacious Design (Light)-color-theme.json
@@ -680,7 +680,7 @@
       "settings": {
         "background": "#FF3399",
         "fontStyle": "",
-        "foreground": "#F8F8F0"
+        "foreground": "#B3B3D4"
       }
     },
     {


### PR DESCRIPTION
Fixes #30 with the foreground color from the dark theme. Increases contrast from [1.01](https://polypane.app/color-contrast/#fg=#F8F8F0&bg=#f8f8ff&level=aa&format=hex) (invisible) to [1.93](https://polypane.app/color-contrast/#fg=#B3B3D4&bg=#f8f8ff&level=aa&format=hex).